### PR TITLE
Fast reverse

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -234,6 +234,9 @@ import qualified Data.Text.Internal.Functions as F
 import qualified Data.Text.Internal.Encoding.Utf8 as U8
 import qualified Data.Text.Internal.Encoding.Utf16 as U16
 import Data.Text.Internal.Search (indices)
+import Data.Word (byteSwap64)
+import Data.Text.Internal.Unsafe.Shift (UnsafeShift(..))
+import Data.Bits hiding (shiftL, shiftR)
 #if defined(__HADDOCK__)
 import Data.ByteString (ByteString)
 import qualified Data.Text.Lazy as L
@@ -649,13 +652,56 @@ intersperse c t = unstream (S.intersperse (safe c) (stream t))
 reverse :: Text -> Text
 reverse (Text arr off len) = Text (A.run go) 0 len
   where
+  allSingleByte x = x .&. 0x8080808080808080 == 0
   go :: forall s. ST s (A.MArray s)
   go = do
     marr <- A.new len
     let
       e = off + len
-      loop i j =
+      e64 = e `shiftR` 3
+      loop i j = 
+        let i64 = i `shiftR` 3
+            j64 = j `shiftR` 3
+            x = A.unsafeIndex64 arr i64
+            r = byteSwap64 x
+        in
         if i >= e then return marr
+        else if i .&. 0x7 == 0 && i64 < e64 && allSingleByte x then
+          let a = j .&. 0x7
+              k = 8 - a
+              sa = a `shiftL` 3
+              sk = k `shiftL` 3
+              alignJ j r =
+                if j .&. 0x7 == 0 then
+                  fastLoop (i64 + 1) (j `shiftR` 3) r
+                else do
+                  A.unsafeWrite marr (j - 1) (P.fromIntegral $ r .&. 0xff)
+                  alignJ (j - 1) (r `shiftR` 8)
+              fastAlignedLoop i64 j64 =
+                let x = A.unsafeIndex64 arr i64
+                    r = byteSwap64 x
+                in if i64 < e64 && allSingleByte x then do
+                  A.unsafeWrite64 marr (j64 - 1) r
+                  fastAlignedLoop (i64 + 1) (j64 - 1)
+                else loop (i64 `shiftL` 3) (j64 `shiftL` 3)
+              fastLoop i64 j64 rest =
+                let x = A.unsafeIndex64 arr i64
+                in if i64 < e64 && allSingleByte x then do
+                  A.unsafeWrite64 marr (j64 - 1) (byteSwap64 $ rest .|. (x `shiftL` sk))
+                  fastLoop (i64 + 1) (j64 - 1) (x `shiftR` sa)
+                else
+                  let writeRest j r =
+                        if j .&. 0x7 == a then
+                          loop (i64 `shiftL` 3) j
+                        else do
+                          A.unsafeWrite marr (j - 1) (P.fromIntegral $ r .&. 0xff)
+                          writeRest (j - 1) (r `shiftR` 8)
+                  in writeRest (j64 `shiftL` 3) rest
+          in if j .&. 0x7 == 0 then do
+               let j64 = j `shiftR` 3
+               A.unsafeWrite64 marr (j64 - 1) r
+               fastAlignedLoop (i64 + 1) (j64 - 1)
+             else alignJ j x  -- if LITTLE endian
         else do
           _ <- unsafeWrite marr (j - d) c
           loop (i + d) (j - d)


### PR DESCRIPTION
the original algorithm created a reversed stream and the UTF8 version was almost twice as slow;
reverse implemented directly is actually faster and in the last commit i (optimistically) try to use bit parallelism and reverse 64bits (8 bytes) at a time (only applicable when all the code points are single bytes) - this is (unsurprisingly) much faster
e.g. for the `ascii-small` data set:
```
2.636 ms   (2.629 ms .. 2.643 ms) -- UTF16
4.951 ms   (4.941 ms .. 4.964 ms) -- UTF8 (v0, using streams as UTF16)
1.650 ms   (1.646 ms .. 1.654 ms) -- no stream
184.1 μs   (183.9 μs .. 184.3 μs) -- fast but incorrect algorithm
193.8 μs   (192.6 μs .. 194.9 μs) -- deal with alignment
213.7 μs   (213.4 μs .. 214.0 μs) -- check that all code points are single bytes
```

here are benchmarks for other data sets:
```
UTF16 vs. UTF8 simple vs. UTF8 bit parallel:

benchmarking Pure/reverse/Text+tiny
time                 306.4 ns   (306.2 ns .. 306.7 ns)
time                 202.2 ns   (201.8 ns .. 202.6 ns)
time                 205.2 ns   (204.9 ns .. 205.6 ns)
benchmarking Pure/reverse/Text+ascii-small
time                 2.631 ms   (2.625 ms .. 2.639 ms)
time                 1.654 ms   (1.648 ms .. 1.658 ms)
time                 210.3 μs   (210.2 μs .. 210.4 μs)
benchmarking Pure/reverse/Text+ascii
time                 2.147 s    (2.101 s .. 2.225 s)
time                 1.298 s    (1.268 s .. 1.339 s)
time                 204.7 ms   (183.0 ms .. 236.4 ms)
benchmarking Pure/reverse/Text+english
time                 145.6 ms   (140.0 ms .. 149.7 ms)
time                 89.29 ms   (87.01 ms .. 91.77 ms)
time                 15.97 ms   (15.57 ms .. 16.54 ms)
benchmarking Pure/reverse/Text+russian
time                 224.4 μs   (224.2 μs .. 224.7 μs)
time                 195.5 μs   (195.3 μs .. 195.7 μs)
time                 236.9 μs   (236.8 μs .. 237.1 μs)
benchmarking Pure/reverse/Text+japanese
time                 154.8 μs   (154.6 μs .. 155.0 μs)
time                 161.5 μs   (161.4 μs .. 161.7 μs)
time                 178.5 μs   (178.4 μs .. 178.6 μs)
```

Note that we are ~ 10x faster on ascii/english !!
in `russian` almost all characters have 2 bytes in UTF8 and in `japanese` almost all have 3 bytes in UTF8 (but 1 word in UTF16, which is better in this case)

TODO:
- [ ] this only works for little endian architectures; add big endian
- [ ]  32-bit version