### PR TITLE
Fast textCompare using memcmp

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -410,17 +410,13 @@ textDataType = mkDataType "Data.Text.Text" [packConstr]
 
 -- | /O(n)/ Compare two 'Text' values lexicographically.
 compareText :: Text -> Text -> Ordering
-compareText ta@(Text _arrA _offA lenA) tb@(Text _arrB _offB lenB)
-    | lenA == 0 && lenB == 0 = EQ
-    | otherwise              = go 0 0
-  where
-    go !i !j
-        | i >= lenA || j >= lenB = compare lenA lenB
-        | a < b                  = LT
-        | a > b                  = GT
-        | otherwise              = go (i+di) (j+dj)
-      where Iter a di = iter ta i
-            Iter b dj = iter tb j
+compareText (Text arrA offA lenA) (Text arrB offB lenB)
+    | lenA == 0 || lenB == 0 = compare lenA lenB
+    | otherwise              =
+        case A.compare arrA offA arrB offB (min lenA lenB) of
+          LT -> LT
+          GT -> GT
+          EQ -> compare lenA lenB
 
 -- -----------------------------------------------------------------------------
 -- * Conversion to/from 'Text'

--- a/Data/Text/Array.hs
+++ b/Data/Text/Array.hs
@@ -36,6 +36,7 @@ module Data.Text.Array
 
     , empty
     , equal
+    , compare
 #if defined(ASSERTS)
     , length
 #endif
@@ -88,7 +89,7 @@ import GHC.Base (IO(..), RealWorld, ByteArray#, MutableByteArray#, Int(..), (-#)
 import GHC.Exts (Ptr(..))
 import GHC.ST (ST(..), runST)
 import GHC.Word (Word8(..), Word32(..), Word64(..))
-import Prelude hiding (length, read)
+import Prelude hiding (length, read, compare)
 
 -- | Immutable array type.
 data Array = Array {
@@ -278,6 +279,22 @@ equal arrA offA arrB offB count = inlinePerformIO $ do
                      (aBA arrB) (fromIntegral offB) (fromIntegral count)
   return $! i == 0
 {-# INLINE equal #-}
+
+-- | Compare portions of two arrays for equality.  No bounds checking
+-- is performed.
+compare :: Array                  -- ^ First
+        -> Int                    -- ^ Offset into first
+        -> Array                  -- ^ Second
+        -> Int                    -- ^ Offset into second
+        -> Int                    -- ^ Count
+        -> Ordering
+compare arrA offA arrB offB count = inlinePerformIO $ do
+  i <- memcmp (aBA arrA) (fromIntegral offA)
+                     (aBA arrB) (fromIntegral offB) (fromIntegral count)
+  if i == 0 then return EQ
+    else if i > 0 then return GT
+    else return LT
+{-# INLINE compare #-}
 
 foreign import ccall unsafe "_hs_text_memcmp" memcmp
     :: ByteArray# -> CSize -> ByteArray# -> CSize -> CSize -> IO CInt


### PR DESCRIPTION
here are the benchmarks comparing
* the original UTF16 implementation
* faster UTF16 (see https://github.com/kuk0/text/commit/d2b4675d57ce29ac753337fccc9fc3d39ec5fa1d)
* the same code for UTF8 (surprisingly slower than UTF16)
* memcmp for UTF8 - blazing fast
```
benchmarking Pure/compareText/Text+tiny
time                 82.79 ns   (82.76 ns .. 82.83 ns)
time                 60.84 ns   (60.79 ns .. 60.93 ns)
time                 84.58 ns   (84.50 ns .. 84.72 ns)
time                 54.08 ns   (54.06 ns .. 54.10 ns)
benchmarking Pure/compareText/Text+ascii-small
time                 588.1 μs   (588.0 μs .. 588.3 μs)
time                 293.9 μs   (293.8 μs .. 294.0 μs)
time                 558.7 μs   (532.3 μs .. 604.2 μs)
time                 11.70 μs   (11.67 μs .. 11.73 μs)
benchmarking Pure/compareText/Text+ascii
time                 510.9 ms   (510.5 ms .. 511.3 ms)
time                 257.1 ms   (256.4 ms .. 257.6 ms)
time                 461.2 ms   (459.3 ms .. 464.9 ms)
time                 14.92 ms   (14.88 ms .. 15.00 ms)
benchmarking Pure/compareText/Text+english
time                 34.14 ms   (34.13 ms .. 34.15 ms)
time                 17.19 ms   (17.18 ms .. 17.20 ms)
time                 30.67 ms   (30.66 ms .. 30.69 ms)
time                 875.0 μs   (865.4 μs .. 886.9 μs)
benchmarking Pure/compareText/Text+russian
time                 54.49 μs   (54.48 μs .. 54.51 μs)
time                 27.26 μs   (27.26 μs .. 27.26 μs)
time                 89.85 μs   (89.81 μs .. 89.90 μs)
time                 1.325 μs   (1.324 μs .. 1.326 μs)
benchmarking Pure/compareText/Text+japanese
time                 37.88 μs   (37.87 μs .. 37.89 μs)
time                 18.82 μs   (18.81 μs .. 18.82 μs)
time                 96.19 μs   (96.15 μs .. 96.24 μs)
time                 1.413 μs   (1.412 μs .. 1.414 μs)
```